### PR TITLE
build: skip type checking of dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: 'Publish package'
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+          node-version: 14.x
+
+      - name: Clean install dependencies
+        run: |
+          npm install
+
+      - name: Prepare for private registry
+        run: |
+          rm -f .npmrc
+          curl -u s-rbmh-bld-webcomponents:${{ secrets.ARTIFACTORY_API_KEY }} https://artifactory.redbullmediahouse.com/api/npm/auth > .npmrc 
+          echo "registry=https://artifactory.redbullmediahouse.com/artifactory/api/npm/rb-web-components/" >> .npmrc
+
+      - name: Publish package
+        run: |
+          npm publish

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/vue-output-target",
+  "name": "@rbmh-design-system/vue-output-target",
   "version": "0.1.8",
   "description": "Vue output target for @stencil/core components.",
   "main": "dist/index.cjs.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "outDir": "dist",
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "src/resources"]


### PR DESCRIPTION
### Scope
Right now the web-components build fails when installing this dep, because it does not compile/transpile.